### PR TITLE
Add execution-policy platform matching logic to shard workers.

### DIFF
--- a/src/main/java/build/buildfarm/worker/ExecutionPolicies.java
+++ b/src/main/java/build/buildfarm/worker/ExecutionPolicies.java
@@ -1,0 +1,42 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import build.bazel.remote.execution.v2.Platform;
+import build.buildfarm.v1test.ExecutionPolicy;
+
+public final class ExecutionPolicies {
+  private ExecutionPolicies() {
+    // Utility
+  }
+
+  /**
+   * Adds execution policy platform psuedo-properties advertising the platform supports any of its
+   * configured execution policies.
+   *
+   * @param platform The platform to adjust with execution-policy pseudo-properties.
+   * @param policies The execution policies to add to the platform's properties.
+   * @return An adjusted platform containing the execution-policy pseudo-properties.
+   */
+  public static Platform adjustPlatformProperties(Platform platform, Iterable<ExecutionPolicy> policies) {
+    Platform.Builder platformWithPoliciesBuilder = platform.toBuilder();
+    for (ExecutionPolicy policy : policies) {
+      platformWithPoliciesBuilder.addPropertiesBuilder()
+          .setName("execution-policy")
+          .setValue(policy.getName());
+    }
+    return platformWithPoliciesBuilder.build();
+  }
+}

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -49,6 +49,7 @@ import build.buildfarm.common.grpc.Retrier;
 import build.buildfarm.common.grpc.Retrier.Backoff;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.instance.Instance.MatchListener;
+import build.buildfarm.worker.ExecutionPolicies;
 import build.buildfarm.worker.RetryingMatchListener;
 import build.buildfarm.worker.WorkerContext;
 import build.buildfarm.v1test.ExecuteEntry;
@@ -113,7 +114,7 @@ class ShardWorkerContext implements WorkerContext {
   private final Duration defaultActionTimeout;
   private final Duration maximumActionTimeout;
   private final Map<String, QueueEntry> activeOperations = Maps.newConcurrentMap();
-  
+
   ShardWorkerContext(
       String name,
       Platform platform,
@@ -132,7 +133,6 @@ class ShardWorkerContext implements WorkerContext {
       Duration defaultActionTimeout,
       Duration maximumActionTimeout) {
     this.name = name;
-    this.platform = platform;
     this.operationPollPeriod = operationPollPeriod;
     this.operationPoller = operationPoller;
     this.inlineContentLimit = inlineContentLimit;
@@ -147,6 +147,9 @@ class ShardWorkerContext implements WorkerContext {
     this.deadlineAfterUnits = deadlineAfterUnits;
     this.defaultActionTimeout = defaultActionTimeout;
     this.maximumActionTimeout = maximumActionTimeout;
+
+    this.platform =  ExecutionPolicies.adjustPlatformProperties(platform, policies);
+    logger.fine(String.format("%s will match against platform %s", this, platform));
   }
 
   private static Retrier createBackplaneRetrier() {


### PR DESCRIPTION
This centralizes the bit of logic needed for all workers to map execution
policy psuedo-properties to their platform.